### PR TITLE
Moved timestamp specifics into abstraction layer.

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,4 +1,7 @@
 from __future__ import print_function
+
+import datetime
+
 from teamscale_client import TeamscaleClient
 
 TEAMSCALE_URL = "http://localhost:8080"
@@ -26,5 +29,5 @@ if __name__ == '__main__':
         }
     ]
     client = TeamscaleClient(TEAMSCALE_URL, USERNAME, PASSWORD, PROJECT_NAME)
-    response = client.upload_findings(findings, 1459554747999, "TestCommit", "test-partition")
+    response = client.upload_findings(findings, datetime.datetime.now(), "TestCommit", "test-partition")
     print("Request result: %s" % (response.text,))

--- a/teamscale_client/teamscale_client.py
+++ b/teamscale_client/teamscale_client.py
@@ -67,7 +67,7 @@ class TeamscaleClient:
                         },
                         ...
                     ]
-            timestamp (int): timestamp (unix format) for which to upload the findings
+            timestamp (datetime.datetime): timestamp for which to upload the findings
             message (str): The message to use for the generated upload commit
             partition (str): The partition's id into which the findings should be added
 
@@ -96,7 +96,7 @@ class TeamscaleClient:
                         },
                         ...
                     ]
-            timestamp (int): timestamp (unix format) for which to upload the metrics
+            timestamp (datetime.datetime): timestamp for which to upload the metrics
             message (str): The message to use for the generated upload commit
             partition (str): The partition's id into which the metrics should be added
 
@@ -114,7 +114,7 @@ class TeamscaleClient:
         Args:
             service_name (str): The service name to which to upload the data
             json_data: data in json format
-            timestamp (int): timestamp (unix format) for which to upload the data
+            timestamp (datetime.datetime): timestamp (unix format) for which to upload the data
             message (str): The message to use for the generated upload commit
             partition (str): The partition's id into which the data should be added
 
@@ -126,7 +126,7 @@ class TeamscaleClient:
         """
         service_url = self.get_project_service_url(service_name)
         parameters = {
-            "t": timestamp,
+            "t": int(timestamp.timestamp() * 1000),
             "message": message,
             "partition": partition,
             "skip-session": "true"


### PR DESCRIPTION
Do not expose end-users to how the REST API computes timestamps.
