### PR TITLE
Implemented rich comparison method__eq__ for easily comparing baselines

### DIFF
--- a/teamscale_client/data.py
+++ b/teamscale_client/data.py
@@ -133,8 +133,14 @@ class Baseline(object):
         self.name = name
         self.description = description
         self.timestamp = timestamp
-        if(date is not None):
+        if date is not None:
             self._set_date(date)
+
+    def __hash__(self):
+        return hash((self.name, self.description, self.timestamp))
+
+    def __eq__(self, other):
+        return isinstance(other, Baseline) and hash(other) == hash(self)
 
     def _get_date(self):
         return datetime.datetime.fromtimestamp(float(self._timestamp))


### PR DESCRIPTION
Comparing baselines without a sufficient **eq** method is error prone, because it have to be implemented at each location a comparison should take place.
