### PR TITLE
Improved project variable naming

### DIFF
--- a/examples/example_architecture_upload.py
+++ b/examples/example_architecture_upload.py
@@ -14,9 +14,9 @@ TEAMSCALE_URL = "http://localhost:8080"
 USERNAME = "admin"
 ACCESS_TOKEN = "ide-access-token"
 
-PROJECT_NAME = "test"
+PROJECT_ID = "test"
 
 if __name__ == '__main__':
-    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_NAME)
+    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_ID)
 
     client.upload_architectures({"architectures/system.architecture": "/path/to/system.architecture"}, datetime.datetime.now(), "Upload architecture")

--- a/examples/example_baselines.py
+++ b/examples/example_baselines.py
@@ -15,14 +15,14 @@ TEAMSCALE_URL = "http://localhost:8080"
 USERNAME = "admin"
 ACCESS_TOKEN = "ide-access-token"
 
-PROJECT_NAME = "test"
+PROJECT_ID = "test"
 
 def show_baselines(client):
     baselines = client.get_baselines()
     print([str(baseline) for baseline in baselines])
 
 if __name__ == '__main__':
-    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_NAME)
+    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_ID)
 
     baseline = Baseline("Test Baseline", "This is a test description", datetime.datetime.now())
 

--- a/examples/example_findings_upload.py
+++ b/examples/example_findings_upload.py
@@ -16,10 +16,10 @@ TEAMSCALE_URL = "http://localhost:8080"
 USERNAME = "admin"
 ACCESS_TOKEN = "ide-access-token"
 
-PROJECT_NAME = "test"
+PROJECT_ID = "test"
 
 if __name__ == '__main__':
-    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_NAME)
+    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_ID)
 
     # Add a new group that will contain findings
     response = client.add_findings_group("Group 1", "externals-.*")

--- a/examples/example_metric_upload.py
+++ b/examples/example_metric_upload.py
@@ -14,10 +14,10 @@ TEAMSCALE_URL = "http://localhost:8080"
 USERNAME = "admin"
 ACCESS_TOKEN = "ide-access-token"
 
-PROJECT_NAME = "foo"
+PROJECT_ID = "foo"
 
 if __name__ == '__main__':
-    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_NAME)
+    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_ID)
 
     entry = MetricEntry("src/Foo.java", {"sample_metric_id" : 10})
     entry2 = MetricEntry("-architectures-/system.architecture/src/empty/", {"sample_metric_id" : 6})

--- a/examples/example_metrics_descriptions.py
+++ b/examples/example_metrics_descriptions.py
@@ -11,10 +11,10 @@ TEAMSCALE_URL = "http://localhost:8080"
 USERNAME = "admin"
 ACCESS_TOKEN = "ide-access-token"
 
-PROJECT_NAME = "foo"
+PROJECT_ID = "foo"
 
 if __name__ == '__main__':
-    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_NAME)
+    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_ID)
 
     description = MetricDescription("sample_metric_id", "Sample Metric", "A great sample description", "Sample Metrics")
     client.add_metric_descriptions([description])

--- a/examples/example_non_code_metric_upload.py
+++ b/examples/example_non_code_metric_upload.py
@@ -15,10 +15,10 @@ TEAMSCALE_URL = "http://localhost:8080"
 USERNAME = "admin"
 ACCESS_TOKEN = "ide-access-token"
 
-PROJECT_NAME = "test"
+PROJECT_ID = "test"
 
 if __name__ == '__main__':
-    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_NAME)
+    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_ID)
 
     entry = NonCodeMetricEntry("/non/code/metric/path", "This is a test content", 3, {AssessmentMetricColors.RED: 2, AssessmentMetricColors.GREEN : 1}, 25.0)
     entry2 = NonCodeMetricEntry("/non/code/metric/path2", "This is a test content 2", 5, {AssessmentMetricColors.RED: 1, AssessmentMetricColors.GREEN : 4}, 40.)

--- a/examples/example_projects.py
+++ b/examples/example_projects.py
@@ -13,7 +13,7 @@ TEAMSCALE_URL = "http://localhost:8080"
 USERNAME = "admin"
 ACCESS_TOKEN = "ide-access-token"
 
-PROJECT_NAME = "test"
+PROJECT_ID = "test"
 
 ANALYSIS_PROFILE = "Python (default)"
 INCLUDE_PATTERN = "**.py"
@@ -83,7 +83,7 @@ def create_project_with_svn_connector():
 
 
 if __name__ == '__main__':
-    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_NAME)
+    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_ID)
     show_projects(client)
 
     create_project_with_file_system_connector()

--- a/examples/example_report_upload.py
+++ b/examples/example_report_upload.py
@@ -14,10 +14,10 @@ TEAMSCALE_URL = "http://localhost:8080"
 USERNAME = "admin"
 ACCESS_TOKEN = "ide-access-token"
 
-PROJECT_NAME = "test"
+PROJECT_ID = "test"
 
 if __name__ == '__main__':
-    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_NAME)
+    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_ID)
 
     files = [ file for file in glob.glob("/path/to/report.xml")]
 

--- a/examples/example_test_coverage_upload.py
+++ b/examples/example_test_coverage_upload.py
@@ -14,10 +14,10 @@ TEAMSCALE_URL = "http://localhost:8080"
 USERNAME = "admin"
 ACCESS_TOKEN = "ide-access-token"
 
-PROJECT_NAME = "test"
+PROJECT_ID = "test"
 
 if __name__ == '__main__':
-    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_NAME)
+    client = TeamscaleClient(TEAMSCALE_URL, USERNAME, ACCESS_TOKEN, PROJECT_ID)
 
     files = [ file for file in glob.glob("/path/to/coverage/files/*.xml")]
 

--- a/teamscale_client/client.py
+++ b/teamscale_client/client.py
@@ -21,7 +21,7 @@ class TeamscaleClient:
         url (str): The url to Teamscale (including the port)
         username (str): The username to use for authentication
         access_token (str): The IDE access token to use for authentication
-        project (str): The project on which to work
+        project (str): The id of the project on which to work
         sslverify: See requests' verify parameter in http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification
         timeout (float): TTFB timeout in seconds, see http://docs.python-requests.org/en/master/user/quickstart/#timeouts
         branch: The branch name for which to upload/retrieve data


### PR DESCRIPTION
It should be made clear in the examples that what we need is the project id not its name.