### PR TITLE
Support for links to findings in teamscale-cli

### DIFF
--- a/teamscale_client/client.py
+++ b/teamscale_client/client.py
@@ -621,7 +621,8 @@ class TeamscaleClient:
                        end_offset=self._get_finding_location_entry(finding_json, 'rawEndOffset', 0),
                        start_line=self._get_finding_location_entry(finding_json, 'rawStartLine', 1),
                        end_line=self._get_finding_location_entry(finding_json, 'rawEndLine', 1),
-                       uniform_path=finding_json['location']['uniformPath'])
+                       uniform_path=finding_json['location']['uniformPath'],
+                       finding_id=finding_json['id'])
 
     def _get_finding_location_entry(self, finding_json, key, defaultValue):
         """Safely extracts a value from the location data of a JSON encoded finding.
@@ -693,6 +694,20 @@ class TeamscaleClient:
             raise ServiceError("ERROR: GET {url}: {r.status_code}:{r.text}".format(url=service_url, r=response))
         return self._finding_from_json(response.json())
 
+    def get_finding_url(self, finding):
+        """Returns the full url pointing to the specified finding in Teamscale,
+        or `None` if the finding does not have an id.
+
+        Args:
+           finding(data.Finding): the finding for which the url should be generated
+
+        Returns:
+            str: The full url
+        """
+        if not finding.finding_id:
+            return None
+        return "{client.url}/findings.html#details/{client.project}/?id={finding_id}"\
+            .format(client=self, finding_id=finding.finding_id)
 
     def get_tasks(self, status="OPEN", details=True, start=0, max=300):
         """Retrieves the tasks for the client's project from the server.

--- a/teamscale_client/data.py
+++ b/teamscale_client/data.py
@@ -32,10 +32,13 @@ class Finding(object):
                                     If this is given, offsets and lines do not need to be filled.
         uniform_path (Optional[str]): The path of the file where the finding is located.
         properties (Optional[dict]): A map of String->Object properties associated with this finding.
+        finding_id (str): The Teamscale internal id of this finding. Can be left empty for findings that do not yet have
+                          an id.
     """
 
-    def __init__(self, finding_type_id, message, assessment=Assessment.YELLOW, start_offset=None, end_offset=None,
-                 start_line=None, end_line=None, identifier=None, uniform_path=None, finding_properties=None):
+    def __init__(self, finding_type_id, message, assessment=Assessment.YELLOW, start_offset=None,
+                 end_offset=None, start_line=None, end_line=None, identifier=None, uniform_path=None,
+                 finding_properties=None, finding_id=None):
         self.findingTypeId = finding_type_id
         self.message = message
         self.assessment = assessment
@@ -47,6 +50,7 @@ class Finding(object):
 
         self.uniformPath = uniform_path
         self.findingProperties = finding_properties
+        self.finding_id = finding_id
 
     def __cmp__(self, other):
         """Compares this finding to another finding."""
@@ -60,6 +64,8 @@ class Finding(object):
 
     def __eq__(self, other):
         """Checks if this finding is equal to the given finding."""
+        if self.finding_id and other.finding_id:
+            return self.finding_id == other.finding_id
         return ((self.uniformPath, self.startLine, self.assessment, self.message, self.endLine, self.endOffset,
                  self.findingTypeId, self.identifier, self.startOffset) ==
                 (other.uniformPath, other.startLine, other.assessment, other.message, other.endLine, other.endOffset,

--- a/tests/teamscale_client_test.py
+++ b/tests/teamscale_client_test.py
@@ -158,7 +158,7 @@ def _get_test_findings():
 def test_finding_json_serialization():
     """Tests that findings json is correctly serialized"""
     findings = _get_test_findings()
-    assert '[{"content": null, "findings": [{"assessment": "YELLOW", "endLine": null, "endOffset": null, "findingProperties": null, "findingTypeId": "test-id", "identifier": null, "message": "message", "startLine": null, "startOffset": null, "uniformPath": null}], "path": "path/to/file"}]' == to_json(findings)
+    assert '[{"content": null, "findings": [{"assessment": "YELLOW", "endLine": null, "endOffset": null, "findingProperties": null, "findingTypeId": "test-id", "finding_id": null, "identifier": null, "message": "message", "startLine": null, "startOffset": null, "uniformPath": null}], "path": "path/to/file"}]' == to_json(findings)
 
 @responses.activate
 def test_get_projects():


### PR DESCRIPTION
- Added `id` to `Finding` class
- Added method for getting the link to a specific finding in Teamscale