### PR TITLE
Update repository option 'Branch Name' to 'Default branch name'

### DIFF
--- a/examples/example_projects.py
+++ b/examples/example_projects.py
@@ -50,7 +50,7 @@ def update_project_with_file_system_connector():
 
 
 def create_project_with_git_connector():
-    git_config = GitSourceCodeConnectorConfiguration(branch_name="master", account=ACCOUNT_NAME_GIT,
+    git_config = GitSourceCodeConnectorConfiguration(default_branch_name="master", account=ACCOUNT_NAME_GIT,
                                                      repository_identifier="Git", included_file_names=INCLUDE_PATTERN)
     project_configuration = ProjectConfiguration(name="Test Project 2", project_id="test-project-002",
                                                  profile=ANALYSIS_PROFILE, connectors=[git_config])

--- a/teamscale_client/client.py
+++ b/teamscale_client/client.py
@@ -502,9 +502,9 @@ class TeamscaleClient:
         if timestamp:
             timestamp_seconds = time.mktime(timestamp.timetuple())
             timestamp_or_head = str(int(timestamp_seconds * 1000))
-        branch_name = branch if branch else self.branch
-        if branch_name:
-            return branch_name + ":" + timestamp_or_head
+        default_branch_name = branch if branch else self.branch
+        if default_branch_name:
+            return default_branch_name + ":" + timestamp_or_head
         return timestamp_or_head
 
     def get_global_service_url(self, service_name):

--- a/teamscale_client/data.py
+++ b/teamscale_client/data.py
@@ -343,7 +343,6 @@ class SourceCodeConnectorConfiguration(ConnectorConfiguration):
                                                Empty by default.
         branch_transformation (Optional[str]): Regex transformations that are applied to the branch names
                                                of the repository. Empty by default.
-        path_suffix (Optional[str]): The suffix to append to the base URL of the repository. Empty by default.
     """
 
     def __init__(self, connector_type, included_file_names, excluded_file_names="", repository_identifier="repository1",
@@ -351,7 +350,7 @@ class SourceCodeConnectorConfiguration(ConnectorConfiguration):
                  content_exclude="", polling_interval=60, prepend_repository_identifier=False, end_revision="",
                  text_filter="", source_library_connector=False, run_to_exhaustion=False, delta_size=500,
                  path_prefix_transformation="", path_transformation="", encoding="", author_transformation="",
-                 branch_transformation="", path_suffix="", preserve_empty_commits=False):
+                 branch_transformation="", preserve_empty_commits=False):
         super(SourceCodeConnectorConfiguration, self).__init__(connector_type)
         self.options = {
             "Included file names": included_file_names,
@@ -374,7 +373,6 @@ class SourceCodeConnectorConfiguration(ConnectorConfiguration):
             "Encoding": encoding,
             "Author transformation": author_transformation,
             "Branch transformation": branch_transformation,
-            "Path suffix": path_suffix,
             "Preserve empty commits": preserve_empty_commits
         }
 
@@ -412,7 +410,7 @@ class GitSourceCodeConnectorConfiguration(SourceCodeConnectorConfiguration):
     """Represents a Teamscale Git connector configuration.
 
     Args:
-        branch_name (str): Name of the branch that should be analyzed. If not provided, the master branch will be used.
+        default_branch_name (str): Name of the branch that should be analyzed. If not provided, the master branch will be used.
                            If `enable_branch_analysis` is set to `True`, this becomes the default branch.
         account (str): Name of the Teamscale account to use to connect to the repository.
         path_suffix (Optional[str]): The suffix to append to the base URL of the repository. Empty by default.
@@ -421,10 +419,10 @@ class GitSourceCodeConnectorConfiguration(SourceCodeConnectorConfiguration):
                                                    Defaults to `10`.
     """
 
-    def __init__(self, branch_name, account, path_suffix="", include_submodules=False,
+    def __init__(self, default_branch_name, account, path_suffix="", include_submodules=False,
                  submodule_recursion_depth=10, connector_type=ConnectorType.GIT, *args, **kwargs):
         super(GitSourceCodeConnectorConfiguration, self).__init__(connector_type=connector_type, *args, **kwargs)
-        self.options["Branch Name"] = branch_name
+        self.options["Default branch name"] = default_branch_name
         self.options["Account"] = account
         self.options["Path suffix"] = path_suffix
         self.options["Include Submodules"] = include_submodules


### PR DESCRIPTION
- Renamed option
- Removed dictionary field 'Path suffix' from base connector descriptor