### PR TITLE
Update TFS connector name for Teamscale 5.6 and later

### DIFF
--- a/teamscale_client/constants.py
+++ b/teamscale_client/constants.py
@@ -138,7 +138,7 @@ class UnitTestReportFormats:
 class ConnectorType:
     """Connector types."""
 
-    TFS = "TFS"
+    TFS = "Azure DevOps TFVC (TFS)"
 
     FILE_SYSTEM = "File System"
 


### PR DESCRIPTION
The name of the TFS connector was changed in Teamscale for version 5.6.
With the current version of the python client it is no longer possible to create TFS projects.

This pull requests updates the name of the TFS connector to enable TFS project creation again.