### PR TITLE
Fix too many opened files bug

### DIFF
--- a/teamscale_client/client.py
+++ b/teamscale_client/client.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import requests
 from requests.auth import HTTPBasicAuth
 import time
+import io
 
 import simplejson as json
 
@@ -293,7 +294,11 @@ class TeamscaleClient:
             "adjusttimestamp": "true",
             "movetolastcommit": str(move_to_last_commit).lower()
         }
-        multiple_files = [('report', open(filename, 'rb')) for filename in report_files]
+        multiple_files = []
+        for filename in report_files:
+            with open(filename, 'rb') as inputfile:
+                dataobj = io.BytesIO(inputfile.read())
+                multiple_files.append(('report', dataobj))
         response = requests.post(service_url, params=parameters, auth=self.auth_header, verify=self.sslverify,
                                  files=multiple_files, timeout=self.timeout)
         if not response.ok:


### PR DESCRIPTION
When client is used to upload a big number of files
a "OSError: [Errno 24] Too many open files" occurs

> File "c:\users\administrator\teamscale-client\lib\site-packages\teamscale_client\client.py", line 280, in upload_report
>    multiple_files = [('report', open(filename, 'rb')) for filename in report_files]
>  File "c:\users\administrator\teamscale-client\lib\site-packages\teamscale_client\client.py", line 280, in <listcomp>
>    multiple_files = [('report', open(filename, 'rb')) for filename in report_files]
> OSError: [Errno 24] Too many open files