### PR TITLE
add __hash__ to class Finding

### DIFF
--- a/teamscale_client/data.py
+++ b/teamscale_client/data.py
@@ -88,7 +88,24 @@ class Finding:
         """Checks if this finding is less than the given finding."""
         return (self.uniformPath, self.startLine, self.endLine) < (other.uniformPath, other.startLine, other.endLine)
 
-
+    def __hash__(self) -> int:
+        if self.finding_id:
+            return hash(self.finding_id)
+        else:
+            return hash(
+                (
+                    self.uniformPath,
+                    self.startLine,
+                    self.assessment,
+                    self.message,
+                    self.endLine,
+                    self.endOffset,
+                    self.findingTypeId,
+                    self.identifier,
+                    self.startOffset,
+                )
+            )
+        
 @auto_str
 class FileFindings:
     """Representation of a file and its findings.


### PR DESCRIPTION
This PR adds a `__hash__` function to class `data.Finding`. This is to allow creating `sets` of Findings, e.g.:

```python
new_findings = set(merge_request_findings).difference(main_findings)
``` 

The hash is calculated based on the `finding_id` if it exists. Otherwise the same set of fields is used as for `__eq__`.